### PR TITLE
tell the dramatiq worker which broker to use

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,4 +4,4 @@ RUN pip install 'dramatiq[rabbitmq]'
 RUN pip install requests
 
 ADD actor.py actor.py
-ENTRYPOINT ["/usr/local/bin/dramatiq", "actor"]
+ENTRYPOINT ["/usr/local/bin/dramatiq", "actor:broker1"]


### PR DESCRIPTION
Unless you tell dramatiq which `broker` to use, it'll try to load the global broker (which is why calling `set_broker(broker1)` works just fine). The fix is to explicitly tell dramatiq which broker you want to use for a particular set of workers.